### PR TITLE
Add i18n support with QtLinguist.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ set_package_properties("exiv2"     PROPERTIES
                        PURPOSE     "Library to manage image metadata"
 )
 
+include(i18nUtils)
+
 include_directories($<TARGET_PROPERTY:exiv2lib,INTERFACE_INCLUDE_DIRECTORIES>
                     $<TARGET_PROPERTY:Qt5::Widgets,INTERFACE_INCLUDE_DIRECTORIES>
                     $<TARGET_PROPERTY:Qt5::Core,INTERFACE_INCLUDE_DIRECTORIES>
@@ -68,6 +70,8 @@ set(imagemosaicwall_core_SRCS ${CMAKE_SOURCE_DIR}/mainwindow.cpp
                               ${CMAKE_SOURCE_DIR}/imageprocessing.cpp
                               ${CMAKE_SOURCE_DIR}/progressbutton.cpp
                               ${CMAKE_SOURCE_DIR}/asyncdirectoryscanner.cpp
+                              ${i18n_QRC_SRCS}
+                              ${i18n_QM}
 )
 
 qt5_wrap_ui(imagemosaicwall_core_SRCS ${CMAKE_SOURCE_DIR}/mainwindow.ui

--- a/cmake/modules/i18nUtils.cmake
+++ b/cmake/modules/i18nUtils.cmake
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2020 by Gilles Caulier, <caulier dot gilles at gmail dot com>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+# --- Translations rules (i18n)
+
+find_package(Qt5 "5.6.0" REQUIRED
+             NO_MODULE COMPONENTS
+             Core
+             LinguistTools              # for i18n
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/i18n/i18n_list.cmake)
+
+set_source_files_properties(${translation_files} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/i18n)
+
+foreach(file ${translation_files})
+
+    if(NOT EXISTS "${file}")
+
+       message(STATUS "Translation file ${file} do not exists yet.")
+       message(STATUS "It will be created in ${CMAKE_CURRENT_SOURCE_DIR}/i18n")
+       message(STATUS "Don't forget to add this new file on git repository.")
+
+       qt5_create_translation(missing_i18n_QM
+                              ${CMAKE_CURRENT_SOURCE_DIR}
+                              ${file}
+       )
+
+    endif()
+
+endforeach()
+
+qt5_add_translation(i18n_QM
+                    ${translation_files}
+)
+
+foreach(file ${i18n_QM})
+
+    get_filename_component(directory ${file} DIRECTORY)
+    get_filename_component(basename  ${file} NAME)
+
+    set(QM_XML "${QM_XML}<file>${directory}/${basename}</file>")
+
+endforeach()
+
+configure_file(${CMAKE_SOURCE_DIR}/cmake/templates/i18n.qrc.in_cmake ${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc)
+
+qt5_add_resources(i18n_QRC_SRCS
+                  ${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc
+)

--- a/cmake/templates/i18n.qrc.in_cmake
+++ b/cmake/templates/i18n.qrc.in_cmake
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/i18n">
+    @QM_XML@
+    </qresource>
+</RCC>

--- a/dplugin/imagemosaicwallgenericplugin.cpp
+++ b/dplugin/imagemosaicwallgenericplugin.cpp
@@ -60,7 +60,7 @@ ImageMosaicWallPlugin::~ImageMosaicWallPlugin()
 
 QString ImageMosaicWallPlugin::name() const
 {
-    return QString::fromUtf8("Image Mosaic Wall");
+    return tr("Image Mosaic Wall");
 }
 
 QString ImageMosaicWallPlugin::iid() const
@@ -75,13 +75,13 @@ QIcon ImageMosaicWallPlugin::icon() const
 
 QString ImageMosaicWallPlugin::description() const
 {
-    return QString::fromUtf8("A tool to create an image based on a bunch of other images.");
+    return tr("A tool to create an image based on a bunch of other images.");
 }
 
 QString ImageMosaicWallPlugin::details() const
 {
-    return QString::fromUtf8("<p>This tool allows you to create an image based on a bunch of other images. "
-                             "It looks like a mosaic effect.</p>");
+    return tr("<p>This tool allows you to create an image based on a bunch of other images. "
+              "It looks like a mosaic effect.</p>");
 }
 
 QList<DPluginAuthor> ImageMosaicWallPlugin::authors() const
@@ -100,7 +100,7 @@ void ImageMosaicWallPlugin::setup(QObject* const parent)
 {
     DPluginAction* const ac = new DPluginAction(parent);
     ac->setIcon(icon());
-    ac->setText(QString::fromUtf8("Image Mosaic Wall..."));
+    ac->setText(tr("Image Mosaic Wall..."));
     ac->setObjectName(QLatin1String("ImageMosaicWall"));
     ac->setActionCategory(DPluginAction::GenericTool);
 

--- a/i18n/de.ts
+++ b/i18n/de.ts
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>ImageViewer</name>
+    <message>
+        <location filename="../imageviewer.ui" line="23"/>
+        <location filename="../build/ui_imageviewer.h" line="102"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="14"/>
+        <location filename="../build/ui_mainwindow.h" line="408"/>
+        <source>Image Mosaic Wall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="103"/>
+        <location filename="../build/ui_mainwindow.h" line="409"/>
+        <source> Load Base Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="135"/>
+        <location filename="../build/ui_mainwindow.h" line="410"/>
+        <source> Set Image Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="195"/>
+        <location filename="../build/ui_mainwindow.h" line="412"/>
+        <source> Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="218"/>
+        <location filename="../build/ui_mainwindow.h" line="413"/>
+        <source>Variation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="233"/>
+        <location filename="../build/ui_mainwindow.h" line="414"/>
+        <location filename="../mainwindow.cpp" line="81"/>
+        <source>disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="292"/>
+        <location filename="../build/ui_mainwindow.h" line="416"/>
+        <source>Resolution of the output image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="295"/>
+        <location filename="../build/ui_mainwindow.h" line="418"/>
+        <source>Output Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="325"/>
+        <location filename="../build/ui_mainwindow.h" line="419"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="384"/>
+        <location filename="../build/ui_mainwindow.h" line="422"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="471"/>
+        <location filename="../build/ui_mainwindow.h" line="425"/>
+        <source> Set Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="507"/>
+        <location filename="../build/ui_mainwindow.h" line="427"/>
+        <source>Defines how ofte the image is devided in rows and columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="510"/>
+        <location filename="../build/ui_mainwindow.h" line="429"/>
+        <source>Grid </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="522"/>
+        <location filename="../build/ui_mainwindow.h" line="430"/>
+        <source>Rows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="582"/>
+        <location filename="../build/ui_mainwindow.h" line="431"/>
+        <source>Columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="622"/>
+        <location filename="../build/ui_mainwindow.h" line="432"/>
+        <source> Create Mosaic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="657"/>
+        <location filename="../build/ui_mainwindow.h" line="433"/>
+        <source> Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="84"/>
+        <source>very low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="87"/>
+        <source>low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="90"/>
+        <source>medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="93"/>
+        <source>high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="96"/>
+        <source>very high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="116"/>
+        <source>Image Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="121"/>
+        <source>Images in Folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="203"/>
+        <source>%1 images scanned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="261"/>
+        <source>Open Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="263"/>
+        <source>ImageFiles (*.png *.jpg *bmp)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="319"/>
+        <source>%1 of %2 cells processed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="330"/>
+        <source>%1 of %2 images processed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="363"/>
+        <source>JPEG (*.jpg);;PNG (*.png)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="371"/>
+        <source>Load Images Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/fr.ts
+++ b/i18n/fr.ts
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>ImageViewer</name>
+    <message>
+        <location filename="../imageviewer.ui" line="23"/>
+        <location filename="../build/ui_imageviewer.h" line="102"/>
+        <source>Form</source>
+        <translation type="Forme"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="14"/>
+        <location filename="../build/ui_mainwindow.h" line="408"/>
+        <source>Image Mosaic Wall</source>
+        <translation type="Image Mosaic Wall"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="103"/>
+        <location filename="../build/ui_mainwindow.h" line="409"/>
+        <source> Load Base Image</source>
+        <translation type=" Charger l'image de base"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="135"/>
+        <location filename="../build/ui_mainwindow.h" line="410"/>
+        <source> Set Image Folder</source>
+        <translation type=" Configurer le dossier d'images"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="195"/>
+        <location filename="../build/ui_mainwindow.h" line="412"/>
+        <source> Cancel</source>
+        <translation type=" Annuler"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="218"/>
+        <location filename="../build/ui_mainwindow.h" line="413"/>
+        <source>Variation</source>
+        <translation type="Variation"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="233"/>
+        <location filename="../build/ui_mainwindow.h" line="414"/>
+        <location filename="../mainwindow.cpp" line="81"/>
+        <source>disabled</source>
+        <translation type="désactiver"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="292"/>
+        <location filename="../build/ui_mainwindow.h" line="416"/>
+        <source>Resolution of the output image</source>
+        <translation type="Résolution de l'image de sortie"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="295"/>
+        <location filename="../build/ui_mainwindow.h" line="418"/>
+        <source>Output Resolution</source>
+        <translation type="Résolution de la cible"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="325"/>
+        <location filename="../build/ui_mainwindow.h" line="419"/>
+        <source>Width</source>
+        <translation type="Largeur"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="384"/>
+        <location filename="../build/ui_mainwindow.h" line="422"/>
+        <source>Height</source>
+        <translation type="Hauteur"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="471"/>
+        <location filename="../build/ui_mainwindow.h" line="425"/>
+        <source> Set Resolution</source>
+        <translation type=" Valider la résolution"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="507"/>
+        <location filename="../build/ui_mainwindow.h" line="427"/>
+        <source>Defines how ofte the image is devided in rows and columns</source>
+        <translation type="Définir comment l'image sera divisée en lignes et en colonnes"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="510"/>
+        <location filename="../build/ui_mainwindow.h" line="429"/>
+        <source>Grid </source>
+        <translation type="Grille "></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="522"/>
+        <location filename="../build/ui_mainwindow.h" line="430"/>
+        <source>Rows</source>
+        <translation type="Lignes"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="582"/>
+        <location filename="../build/ui_mainwindow.h" line="431"/>
+        <source>Columns</source>
+        <translation type="Colonnes"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="622"/>
+        <location filename="../build/ui_mainwindow.h" line="432"/>
+        <source> Create Mosaic</source>
+        <translation type=" Créer la mosaïque"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="657"/>
+        <location filename="../build/ui_mainwindow.h" line="433"/>
+        <source> Save</source>
+        <translation type=" Sauvegarder"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="84"/>
+        <source>very low</source>
+        <translation type="très basse"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="87"/>
+        <source>low</source>
+        <translation type="basse"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="90"/>
+        <source>medium</source>
+        <translation type="moyenne"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="93"/>
+        <source>high</source>
+        <translation type="haute"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="96"/>
+        <source>very high</source>
+        <translation type="très haute"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="116"/>
+        <source>Image Resolution:</source>
+        <translation type="Résolution de l'image :"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="121"/>
+        <source>Images in Folder:</source>
+        <translation type="Images dan sle dossier :"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="203"/>
+        <source>%1 images scanned</source>
+        <translation type="%1 images annalysées"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="261"/>
+        <source>Open Image</source>
+        <translation type="Ouvrir l'image"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="263"/>
+        <source>ImageFiles (*.png *.jpg *bmp)</source>
+        <translation type="Fichiers images (*.png *.jpg *bmp)"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="319"/>
+        <source>%1 of %2 cells processed</source>
+        <translation type="%1 sur %2 cellules générés"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="330"/>
+        <source>%1 of %2 images processed</source>
+        <translation type="%1 sur %2 images générés"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="363"/>
+        <source>JPEG (*.jpg);;PNG (*.png)</source>
+        <translation type="JPEG (*.jpg);;PNG (*.png)"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="371"/>
+        <source>Load Images Folder</source>
+        <translation type="Charger le dossier d'images"></translation>
+    </message>
+</context>
+</TS>

--- a/i18n/i18n_list.cmake
+++ b/i18n/i18n_list.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 by Gilles Caulier, <caulier dot gilles at gmail dot com>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+# --- List of translations files to process
+
+# Append new file on list here, cmake will create missing files automatically.
+# Dont forget to add new created file on git repository.
+# Use ISO639-1 2 letter language codes as file name.
+# https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+
+set(translation_files
+    ${CMAKE_CURRENT_SOURCE_DIR}/i18n/de.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/i18n/fr.ts
+)

--- a/i18nutils.h
+++ b/i18nutils.h
@@ -1,0 +1,93 @@
+/* ============================================================
+ *
+ * This file is a part of digiKam project
+ * https://www.digikam.org
+ *
+ * Date        : 2019-07-30
+ * Description : i18n helper functions.
+ *
+ * Copyright (C) 2020 by Gilles Caulier <caulier dot gilles at gmail dot com>
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General
+ * Public License as published by the Free Software Foundation;
+ * either version 2, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * ============================================================ */
+
+#ifndef DIGIKAM_I18N_UTILS_H
+#define DIGIKAM_I18N_UTILS_H
+
+// Qt includes
+
+#include <QApplication>
+#include <QString>
+#include <QTranslator>
+#include <QLocale>
+#include <QDebug>
+
+// NOTE: do not use namespace here.
+
+void s_initI18nResource()
+{
+    Q_INIT_RESOURCE(i18n);
+}
+
+void s_cleanupI18nResource()
+{
+    Q_CLEANUP_RESOURCE(i18n);
+}
+
+/**
+ * Load translators system based i18n. Internal method.
+ */
+bool s_loadTranslation(const QString& lang, const QString& name)
+{
+    qDebug() << "Loading i18n" << lang << "for" << name;
+
+    QTranslator* const i18n = new QTranslator(qApp);
+
+    if (!i18n->load(QString::fromLatin1(":/i18n/%1.qm").arg(lang)))
+    {
+        delete i18n;
+        return false;
+    }
+
+    qApp->installTranslator(i18n);
+
+    return true;
+}
+
+/**
+ * Load one translation file from normal i18n packaging installation.
+ * 'name' is the module name to print on the console to debug.
+ */
+void s_loadI18n(const QString& name)
+{
+    // Quote from ecm_create_qm_loader created code:
+    // The way Qt translation system handles plural forms makes it necessary to
+    // have a translation file which contains only plural forms for `en`.
+    // That's why we load the `en` translation unconditionally, then load the
+    // translation for the current locale to overload it.
+
+    const QString en(QStringLiteral("en"));
+
+    s_loadTranslation(en, name);
+
+    QLocale locale = QLocale::system();
+
+    if (locale.name() != en)
+    {
+        if (!s_loadTranslation(locale.name(), name))
+        {
+            s_loadTranslation(locale.bcp47Name(), name);
+        }
+    }
+}
+
+#endif // DIGIKAM_I18N_UTILS_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -9,6 +9,7 @@
 #include "asyncdirectoryscanner.h"
 #include "progressbutton.h"
 #include "ui_mainwindow.h"
+#include "i18nutils.h"
 
 using namespace QtConcurrent;
 
@@ -17,6 +18,9 @@ MainWindow::MainWindow(QWidget *parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+
+    s_initI18nResource();
+    s_loadI18n(QLatin1String("ImageMosaicWall"));
 
     QFile file(":/styles/default.qss");
     file.open(QFile::ReadOnly);
@@ -102,6 +106,8 @@ MainWindow::MainWindow(QWidget *parent)
 MainWindow::~MainWindow()
 {
     delete ui;
+
+    s_cleanupI18nResource();
 }
 
 void MainWindow::updateStatus()


### PR DESCRIPTION
Add i18n support with QtLinguist. This require QtLinguist dependency
Add French translations.
Add German empty German translations file.
Note: to append new translations, go to "i18n" subdir and "edit i18n_list.cmake". That all. New files will be generated and must be appended to git of course.