### PR TITLE
random_shuffle is removed in C++17. code do not compile under MSVC. A…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,31 +69,17 @@ endif()
 
 find_package(Threads)
 
-find_package(LibExiv2 OPTIONAL_COMPONENTS)
+find_package(exiv2lib REQUIRED CONFIG NAMES exiv2)
 
-if(LibExiv2_FOUND AND ("${LibExiv2_VERSION}" VERSION_GREATER "0.27.99"))
-
-    find_package(LibExiv2 REQUIRED)
-    set(EXIV2_PACKAGE_NAME "LibExiv2")
-
-else()
-
-    set(LibExiv2_FOUND FALSE)
-    find_package(exiv2 REQUIRED)
-    set(EXIV2_PACKAGE_NAME "exiv2")
-
-endif()
-
-set_package_properties(${EXIV2_PACKAGE_NAME} PROPERTIES
-                       URL                   "https://www.exiv2.org"
-                       TYPE                  RECOMMENDED
+set_package_properties(exiv2lib PROPERTIES
+                       URL         "https://www.exiv2.org"
+                       TYPE        RECOMMENDED
                        PURPOSE     "Library to manage image metadata"
 )
 
 include(i18nUtils)
 
-include_directories($<TARGET_PROPERTY:exiv2lib,INTERFACE_INCLUDE_DIRECTORIES>
-                    $<TARGET_PROPERTY:Qt${QT_VERSION_MAJOR}::Widgets,INTERFACE_INCLUDE_DIRECTORIES>
+include_directories($<TARGET_PROPERTY:Qt${QT_VERSION_MAJOR}::Widgets,INTERFACE_INCLUDE_DIRECTORIES>
                     $<TARGET_PROPERTY:Qt${QT_VERSION_MAJOR}::Core,INTERFACE_INCLUDE_DIRECTORIES>
                     $<TARGET_PROPERTY:Qt${QT_VERSION_MAJOR}::Gui,INTERFACE_INCLUDE_DIRECTORIES>
                     $<TARGET_PROPERTY:Qt${QT_VERSION_MAJOR}::Concurrent,INTERFACE_INCLUDE_DIRECTORIES>
@@ -136,6 +122,11 @@ set(libimagemosaicwall_core_SRCS
 
 add_library(imagemosaicwallcore STATIC ${libimagemosaicwall_core_SRCS})
 
+target_link_libraries(imagemosaicwallcore
+                      PUBLIC
+                      Exiv2::exiv2lib
+)
+
 if(NOT MSVC)
     target_compile_options(imagemosaicwallcore PRIVATE -fPIC)
 endif()
@@ -157,7 +148,6 @@ if(NOT ENABLE_DPLUGIN)
                           Qt${QT_VERSION_MAJOR}::Gui
                           Qt${QT_VERSION_MAJOR}::Concurrent
 
-                          ${LibExiv2_LIBRARIES}
                           ${CMAKE_THREAD_LIBS_INIT}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,26 @@ find_package(Threads)
 
 find_package(exiv2lib REQUIRED CONFIG NAMES exiv2)
 
+if(exiv2lib_FOUND)
+
+    message(STATUS "Found Exiv2 version ${exiv2lib_VERSION}")
+
+    # Work around the cmake export rules from Exiv2 since 0.28
+
+    if("${exiv2lib_VERSION}" VERSION_GREATER "0.27.99")
+
+        set(exiv2lib_LIBRARIES Exiv2::exiv2lib)
+
+    else()
+
+        set(exiv2lib_LIBRARIES exiv2lib)
+
+    endif()
+
+    message(STATUS "Exiv2 libraries: ${exiv2lib_LIBRARIES}")
+
+endif()
+
 set_package_properties(exiv2lib PROPERTIES
                        URL         "https://www.exiv2.org"
                        TYPE        RECOMMENDED
@@ -124,7 +144,7 @@ add_library(imagemosaicwallcore STATIC ${libimagemosaicwall_core_SRCS})
 
 target_link_libraries(imagemosaicwallcore
                       PUBLIC
-                      Exiv2::exiv2lib
+                      ${exiv2lib_LIBRARIES}
 )
 
 if(NOT MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,18 @@
 #
-# Copyright (c) 2020, Gilles Caulier, <caulier dot gilles at gmail dot com>
+# Copyright (c) 2020-2023, Gilles Caulier, <caulier dot gilles at gmail dot com>
 #
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
+cmake_minimum_required(VERSION "3.16")
+
 project(ImageMosaicWall)
 
-cmake_minimum_required(VERSION "3.1.0")
-
-option(ENABLE_DPLUGIN "Build digiKam plugin version of Image Mosaic Wall tool (default=OFF)" OFF)
-option(BUILD_WITH_QT6 "Build with Qt6, else Qt5"                                             OFF)
+option(ENABLE_DPLUGIN "Build digiKam plugin only of Image Mosaic Wall tool (default=OFF)" OFF)
+option(BUILD_WITH_QT6 "Build with Qt6, else Qt5"                                          OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
+
 if (ENABLE_DPLUGIN)
     include(MacroInstall)
 endif()
@@ -24,6 +25,12 @@ endif()
 
 include(FeatureSummary)
 
+if(MSVC)
+    add_compile_options(/utf-8)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
@@ -33,7 +40,6 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-
 
 if(BUILD_WITH_QT6)
 
@@ -93,7 +99,6 @@ set(imagemosaicwall_core_SRCS ${CMAKE_SOURCE_DIR}/mainwindow.cpp
                               ${i18n_QM}
 )
 
-
 if(Qt6_FOUND)
 
     qt6_wrap_ui(imagemosaicwall_core_SRCS ${CMAKE_SOURCE_DIR}/mainwindow.ui
@@ -123,43 +128,46 @@ if(NOT MSVC)
     target_compile_options(imagemosaicwallcore PRIVATE -fPIC)
 endif()
 
-if(APPLE)
-  add_executable(ImageMosaicWall MACOSX_BUNDLE ${OSX_APP_ICON} ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+if(NOT ENABLE_DPLUGIN)
+
+    if(APPLE)
+        add_executable(ImageMosaicWall MACOSX_BUNDLE ${OSX_APP_ICON} ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+    else()
+        add_executable(ImageMosaicWall ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+    endif()
+
+    target_link_libraries(ImageMosaicWall
+
+                          imagemosaicwallcore
+
+                          Qt${QT_VERSION_MAJOR}::Core
+                          Qt${QT_VERSION_MAJOR}::Widgets
+                          Qt${QT_VERSION_MAJOR}::Gui
+                          Qt${QT_VERSION_MAJOR}::Concurrent
+
+                          exiv2lib
+                         ${CMAKE_THREAD_LIBS_INIT}
+    )
+
+    if(APPLE)
+        set(APPS "\${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app")
+        set(DIRS "\${CMAKE_INSTALL_PREFIX}/share")
+
+        install(TARGETS ${PROJECT_NAME}
+                BUNDLE DESTINATION . COMPONENT Runtime
+                RUNTIME DESTINATION bin COMPONENT Runtime)
+
+        install(CODE "
+            include(BundleUtilities)
+            fixup_bundle(\"${APPS}\"  \"\"  \"${DIRS}\")
+            " COMPONENT Runtime)
+    else()
+        install(TARGETS ImageMosaicWall RUNTIME DESTINATION bin)
+    endif()
+
 else()
-  add_executable(ImageMosaicWall ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-endif()
 
-target_link_libraries(ImageMosaicWall
-
-                      imagemosaicwallcore
-
-                      Qt${QT_VERSION_MAJOR}::Core
-                      Qt${QT_VERSION_MAJOR}::Widgets
-                      Qt${QT_VERSION_MAJOR}::Gui
-                      Qt${QT_VERSION_MAJOR}::Concurrent
-
-                      exiv2lib
-                      ${CMAKE_THREAD_LIBS_INIT}
-)
-
-if(APPLE)
-  set(APPS "\${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}.app")
-  set(DIRS "\${CMAKE_INSTALL_PREFIX}/share")
-
-  install(TARGETS ${PROJECT_NAME}
-    BUNDLE DESTINATION . COMPONENT Runtime
-    RUNTIME DESTINATION bin COMPONENT Runtime
-  )
-
-  install(CODE "
-    include(BundleUtilities)
-    fixup_bundle(\"${APPS}\"  \"\"  \"${DIRS}\")
-  " COMPONENT Runtime)
-else()
-  install(TARGETS ImageMosaicWall RUNTIME DESTINATION bin)
-endif()
-
-if (ENABLE_DPLUGIN)
     add_subdirectory(dplugin)
     MACRO_ADD_UNINSTALL_TARGET()
+
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,12 +69,24 @@ endif()
 
 find_package(Threads)
 
-find_package(exiv2 REQUIRED)
+find_package(LibExiv2 OPTIONAL_COMPONENTS)
 
-set_package_properties("exiv2"     PROPERTIES
-                       DESCRIPTION "Required to build digiKam"
-                       URL         "https://www.exiv2.org"
-                       TYPE        RECOMMENDED
+if(LibExiv2_FOUND AND ("${LibExiv2_VERSION}" VERSION_GREATER "0.27.99"))
+
+    find_package(LibExiv2 REQUIRED)
+    set(EXIV2_PACKAGE_NAME "LibExiv2")
+
+else()
+
+    set(LibExiv2_FOUND FALSE)
+    find_package(exiv2 REQUIRED)
+    set(EXIV2_PACKAGE_NAME "exiv2")
+
+endif()
+
+set_package_properties(${EXIV2_PACKAGE_NAME} PROPERTIES
+                       URL                   "https://www.exiv2.org"
+                       TYPE                  RECOMMENDED
                        PURPOSE     "Library to manage image metadata"
 )
 
@@ -145,8 +157,8 @@ if(NOT ENABLE_DPLUGIN)
                           Qt${QT_VERSION_MAJOR}::Gui
                           Qt${QT_VERSION_MAJOR}::Concurrent
 
-                          exiv2lib
-                         ${CMAKE_THREAD_LIBS_INIT}
+                          ${LibExiv2_LIBRARIES}
+                          ${CMAKE_THREAD_LIBS_INIT}
     )
 
     if(APPLE)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ This application allows you to create an image based on a bunch of other images.
 
 # Dependencies
 
-- Qt5.
-- Cmake 3.x.
-- Exiv2 0.27.x API.
-- extra-cmake-modules
-- digiKam 7.x plugin interface. <https://www.digikam.org> (optional)
+- Qt5 or later.
+- CMake 3.x.
+- Exiv2 0.27.x or later.
+- digiKam 8.x plugin interface. <https://www.digikam.org> (optional)
 
 # Compiling and Installing
 

--- a/dplugin/CMakeLists.txt
+++ b/dplugin/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(Generic_ImageMosaicWall_Plugin
                       Qt${QT_VERSION_MAJOR}::Gui
                       Qt${QT_VERSION_MAJOR}::Concurrent
 
-                      exiv2lib
+                      ${LibExiv2_LIBRARIES}
 )
 
 MACRO_ADD_PLUGIN_INSTALL_TARGET(Generic_ImageMosaicWall_Plugin generic)

--- a/dplugin/CMakeLists.txt
+++ b/dplugin/CMakeLists.txt
@@ -35,8 +35,6 @@ target_link_libraries(Generic_ImageMosaicWall_Plugin
                       Qt${QT_VERSION_MAJOR}::Widgets
                       Qt${QT_VERSION_MAJOR}::Gui
                       Qt${QT_VERSION_MAJOR}::Concurrent
-
-                      ${LibExiv2_LIBRARIES}
 )
 
 MACRO_ADD_PLUGIN_INSTALL_TARGET(Generic_ImageMosaicWall_Plugin generic)

--- a/imageprocessing.cpp
+++ b/imageprocessing.cpp
@@ -1,5 +1,6 @@
 #include "imageprocessing.h"
 #include <algorithm>
+#include <cstdlib>
 #include <QDebug>
 #include <QImage>
 #include <QImageReader>
@@ -17,6 +18,18 @@
 #   define AnyError Error
 #   define kerErrorMessage ErrorCode::kerErrorMessage
 #endif
+
+template<class RandomIt>
+void my_random_shuffle(RandomIt first, RandomIt last)
+{
+    typedef typename std::iterator_traits<RandomIt>::difference_type diff_t;
+
+    for (diff_t i = last - first - 1; i > 0; --i)
+    {
+        using std::swap;
+        swap(first[i], first[std::rand() % (i + 1)]);
+    }
+}
 
 ImageProcessing::ImageProcessing(QObject *parent)
     : QObject(parent)
@@ -189,7 +202,7 @@ void ImageProcessing::calculateMosaicPositions(const QSize gridSize, const int s
     for (uint32_t i = startPos; i < startPos + length; ++i)
         positions.push_back(i);
 
-    std::random_shuffle(positions.begin(), positions.end());
+    my_random_shuffle(positions.begin(), positions.end());
     for (auto pos : positions)
     {
         if (m_skipBackgroundProcess)


### PR DESCRIPTION
…dd new generic method to replace this std call

Older implementation work fine under Linux and MacOS, but later, it's not sure. Fix README
Fix MSVC rules to compile fine with Visual C++2022.